### PR TITLE
10/refactor/chat,message/1

### DIFF
--- a/src/main/java/com/hipo/domain/entity/AccountChatRoom.java
+++ b/src/main/java/com/hipo/domain/entity/AccountChatRoom.java
@@ -19,11 +19,11 @@ public class AccountChatRoom extends BaseTime {
     @Column(name = "accountChatRoom_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "account_id")
     private Account account;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatRoom_id")
     private ChatRoom chatRoom;
 

--- a/src/main/java/com/hipo/domain/entity/ChatRoom.java
+++ b/src/main/java/com/hipo/domain/entity/ChatRoom.java
@@ -1,7 +1,9 @@
 package com.hipo.domain.entity;
 
 import com.hipo.domain.entity.base.BaseBy;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
@@ -11,6 +13,7 @@ import java.util.List;
 @Getter
 @Entity
 @Where(clause = "deleted = false")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoom extends BaseBy {
 
     @Id
@@ -26,9 +29,6 @@ public class ChatRoom extends BaseBy {
 
     @OneToMany(mappedBy = "chatRoom")
     private List<AccountChatRoom> participants = new ArrayList<>();
-
-    protected ChatRoom() {
-    }
 
     public ChatRoom(String name, Account masterAccount) {
         this.name = name;

--- a/src/main/java/com/hipo/domain/entity/Message.java
+++ b/src/main/java/com/hipo/domain/entity/Message.java
@@ -2,7 +2,9 @@ package com.hipo.domain.entity;
 
 import com.hipo.domain.entity.base.BaseTime;
 import com.hipo.domain.entity.enums.MessageType;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
@@ -10,6 +12,7 @@ import javax.persistence.*;
 @Getter
 @Entity
 @Where(clause = "deleted = false")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Message extends BaseTime {
 
     @Id @GeneratedValue
@@ -29,13 +32,15 @@ public class Message extends BaseTime {
     @JoinColumn(name = "chatRoom_id")
     private ChatRoom chatRoom;
 
-    protected Message() {
-    }
-
     public Message(String message, MessageType messageType, Account account, ChatRoom chatRoom) {
         this.message = message;
         this.messageType = messageType;
         this.account = account;
         this.chatRoom = chatRoom;
+    }
+
+    public void deleteMessage() {
+        this.message = "삭제된 메시지 입니다.";
+        this.messageType = MessageType.DELETE;
     }
 }

--- a/src/main/java/com/hipo/domain/entity/enums/MessageType.java
+++ b/src/main/java/com/hipo/domain/entity/enums/MessageType.java
@@ -1,5 +1,5 @@
 package com.hipo.domain.entity.enums;
 
 public enum MessageType {
-    MESSAGE, ENTER
+    MESSAGE, ENTER, DELETE
 }

--- a/src/main/java/com/hipo/repository/ChatRoomRepository.java
+++ b/src/main/java/com/hipo/repository/ChatRoomRepository.java
@@ -1,25 +1,19 @@
 package com.hipo.repository;
 
 import com.hipo.domain.entity.ChatRoom;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomRepositoryCustom {
 
-    @Query("select chatRoom from AccountChatRoom accountChatRoom " +
+    @Query("select distinct chatRoom from AccountChatRoom accountChatRoom " +
             "join accountChatRoom.account account " +
-            "join accountChatRoom.chatRoom chatRoom " +
-            "where account.id = :accountId")
-    Page<ChatRoom> findChatRoom(@Param("accountId") Long accountId, Pageable pageable);
-
-    @Query("select chatRoom from AccountChatRoom accountChatRoom " +
-            "join accountChatRoom.account account " +
-            "join accountChatRoom.chatRoom chatRoom " +
+            "join fetch accountChatRoom.chatRoom chatRoom " +
+            "join fetch chatRoom.participants participants " +
+            "join fetch participants.account chatMember " +
             "where account.id = :accountId")
     List<ChatRoom> findAllChatRoom(@Param("accountId") Long AccountId);
 }

--- a/src/main/java/com/hipo/repository/ChatRoomRepository.java
+++ b/src/main/java/com/hipo/repository/ChatRoomRepository.java
@@ -11,9 +11,9 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatR
 
     @Query("select distinct chatRoom from AccountChatRoom accountChatRoom " +
             "join accountChatRoom.account account " +
-            "join fetch accountChatRoom.chatRoom chatRoom " +
+            "join accountChatRoom.chatRoom chatRoom " +
             "join fetch chatRoom.participants participants " +
             "join fetch participants.account chatMember " +
             "where account.id = :accountId")
-    List<ChatRoom> findAllChatRoom(@Param("accountId") Long AccountId);
+    List<ChatRoom> findAllChatRoom(@Param("accountId") Long accountId);
 }

--- a/src/main/java/com/hipo/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/hipo/repository/ChatRoomRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.hipo.repository;
+
+import com.hipo.domain.entity.ChatRoom;
+import com.querydsl.core.QueryResults;
+import org.springframework.data.domain.Pageable;
+
+public interface ChatRoomRepositoryCustom {
+
+    QueryResults<ChatRoom> findChatRoomByPage(Long accountId, Pageable pageable);
+}

--- a/src/main/java/com/hipo/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/hipo/repository/ChatRoomRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.hipo.repository;
+
+import com.hipo.domain.entity.ChatRoom;
+import com.querydsl.core.QueryResults;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import javax.persistence.EntityManager;
+
+import java.util.Objects;
+
+import static com.hipo.domain.entity.QAccount.account;
+import static com.hipo.domain.entity.QAccountChatRoom.accountChatRoom;
+import static com.hipo.domain.entity.QChatRoom.chatRoom;
+
+public class ChatRoomRepositoryImpl extends QuerydslRepositorySupport implements ChatRoomRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public ChatRoomRepositoryImpl(EntityManager entityManager) {
+        super(ChatRoom.class);
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public QueryResults<ChatRoom> findChatRoomByPage(Long accountId, Pageable pageable) {
+
+        JPAQuery<ChatRoom> query = jpaQueryFactory
+                .select(chatRoom)
+                .from(accountChatRoom)
+                .join(accountChatRoom.account, account)
+                .join(accountChatRoom.chatRoom, chatRoom).fetchJoin()
+                .where(account.id.eq(accountId));
+
+        Objects.requireNonNull(getQuerydsl()).applyPagination(pageable, query);
+
+        return query.fetchResults();
+    }
+}

--- a/src/main/java/com/hipo/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/hipo/repository/ChatRoomRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.hipo.repository;
 
 import com.hipo.domain.entity.ChatRoom;
+import com.hipo.domain.entity.QAccount;
+import com.hipo.domain.entity.QAccountChatRoom;
 import com.querydsl.core.QueryResults;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -8,7 +10,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
 import javax.persistence.EntityManager;
-
 import java.util.Objects;
 
 import static com.hipo.domain.entity.QAccount.account;
@@ -27,11 +28,17 @@ public class ChatRoomRepositoryImpl extends QuerydslRepositorySupport implements
     @Override
     public QueryResults<ChatRoom> findChatRoomByPage(Long accountId, Pageable pageable) {
 
+        QAccountChatRoom accountChatRoomInChatRoom = new QAccountChatRoom("accountChatRoomInChatRoom");
+        QAccount chatRoomMember = new QAccount("chatRoomMember");
+
         JPAQuery<ChatRoom> query = jpaQueryFactory
                 .select(chatRoom)
+                .distinct()
                 .from(accountChatRoom)
                 .join(accountChatRoom.account, account)
-                .join(accountChatRoom.chatRoom, chatRoom).fetchJoin()
+                .join(accountChatRoom.chatRoom, chatRoom)
+                .join(chatRoom.participants, accountChatRoomInChatRoom).fetchJoin()
+                .join(accountChatRoomInChatRoom.account, chatRoomMember).fetchJoin()
                 .where(account.id.eq(accountId));
 
         Objects.requireNonNull(getQuerydsl()).applyPagination(pageable, query);

--- a/src/main/java/com/hipo/repository/MessageRepository.java
+++ b/src/main/java/com/hipo/repository/MessageRepository.java
@@ -1,27 +1,13 @@
 package com.hipo.repository;
 
 import com.hipo.domain.entity.Message;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface MessageRepository extends JpaRepository<Message, Long> {
-
-    @Query("select message from Message message " +
-            "join fetch message.chatRoom chatRoom " +
-            "join fetch message.account account " +
-            "where chatRoom.id = :chatRoomId " +
-            "and not account in (select toAccount from Relation relation " +
-                "join relation.fromAccount fromAccount " +
-                "join relation.toAccount toAccount " +
-                "where fromAccount.id =:accountId and relation.relationState = 'BLOCK') " +
-            "order by message.createDate desc")
-    Slice<Message> findChatRoomMessage(@Param("accountId") Long accountId, @Param("chatRoomId") Long chatRoomId,
-                                       Pageable pageable);
+public interface MessageRepository extends JpaRepository<Message, Long>, MessageRepositoryCustom {
 
     @Query("select message from Message message " +
             "join fetch message.chatRoom chatRoom " +

--- a/src/main/java/com/hipo/repository/MessageRepositoryCustom.java
+++ b/src/main/java/com/hipo/repository/MessageRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.hipo.repository;
+
+import com.hipo.domain.entity.Message;
+import com.querydsl.core.QueryResults;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface MessageRepositoryCustom {
+
+    QueryResults<Message> findChatRoomMessageBySlice(Long accountId, Long chatRoomId, Pageable pageable);
+
+    List<Message> findAllChatRoomMessage(Long accountId, Long chatRoomId);
+}

--- a/src/main/java/com/hipo/repository/MessageRepositoryImpl.java
+++ b/src/main/java/com/hipo/repository/MessageRepositoryImpl.java
@@ -1,0 +1,75 @@
+package com.hipo.repository;
+
+import com.hipo.domain.entity.Message;
+import com.hipo.domain.entity.QAccount;
+import com.hipo.domain.entity.QMessage;
+import com.hipo.domain.entity.enums.RelationState;
+import com.querydsl.core.QueryResults;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.hipo.domain.entity.QChatRoom.chatRoom;
+import static com.hipo.domain.entity.QRelation.relation;
+
+public class MessageRepositoryImpl extends QuerydslRepositorySupport implements MessageRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public MessageRepositoryImpl(EntityManager entityManager) {
+        super(Message.class);
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+
+    @Override
+    public QueryResults<Message> findChatRoomMessageBySlice(Long accountId, Long chatRoomId, Pageable pageable) {
+        QMessage message = new QMessage("message");
+        QAccount messageAccount = new QAccount("messageAccount");
+        QAccount fromAccount = new QAccount("fromAccount");
+        QAccount toAccount = new QAccount("toAccount");
+
+
+        return jpaQueryFactory
+                .selectFrom(message)
+                .join(message.chatRoom, chatRoom)
+                .join(message.account, messageAccount).fetchJoin()
+                .where(chatRoom.id.eq(chatRoomId),
+                        messageAccount.notIn(JPAExpressions
+                                .select(toAccount)
+                                .from(relation)
+                                .join(relation.toAccount, toAccount)
+                                .join(relation.fromAccount, fromAccount)
+                                .where(toAccount.id.eq(accountId),
+                                        relation.relationState.eq(RelationState.BLOCK))))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetchResults();
+    }
+
+    @Override
+    public List<Message> findAllChatRoomMessage(Long accountId, Long chatRoomId) {
+        QMessage message = new QMessage("message");
+        QAccount messageAccount = new QAccount("messageAccount");
+        QAccount fromAccount = new QAccount("fromAccount");
+        QAccount toAccount = new QAccount("toAccount");
+
+        return jpaQueryFactory
+                .selectFrom(message)
+                .join(message.chatRoom, chatRoom)
+                .join(message.account, messageAccount).fetchJoin()
+                .where(chatRoom.id.eq(chatRoomId),
+                        messageAccount.notIn(JPAExpressions
+                                .select(toAccount)
+                                .from(relation)
+                                .join(relation.toAccount, toAccount)
+                                .join(relation.fromAccount, fromAccount)
+                                .where(toAccount.id.eq(accountId),
+                                        relation.relationState.eq(RelationState.BLOCK))))
+                .fetch();
+    }
+}

--- a/src/main/java/com/hipo/service/ChatRoomService.java
+++ b/src/main/java/com/hipo/service/ChatRoomService.java
@@ -1,6 +1,5 @@
 package com.hipo.service;
 
-import com.hipo.web.dto.ChatRoomDto;
 import com.hipo.domain.entity.Account;
 import com.hipo.domain.entity.AccountChatRoom;
 import com.hipo.domain.entity.ChatRoom;
@@ -9,15 +8,14 @@ import com.hipo.exception.NonExistResourceException;
 import com.hipo.repository.AccountChatRoomRepository;
 import com.hipo.repository.AccountRepository;
 import com.hipo.repository.ChatRoomRepository;
+import com.hipo.web.dto.ChatRoomDto;
+import com.querydsl.core.QueryResults;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -69,17 +67,12 @@ public class ChatRoomService {
         chatRoom.updateChatRoomMaster(updateMasterAccount);
     }
 
-    public Iterable<ChatRoomDto> findChatRoom(Long accountId, Pageable pageable, boolean all) {
-        if (all) {
-            return chatRoomRepository.findAllChatRoom(accountId).stream()
-                    .map(ChatRoomDto::new)
-                    .collect(Collectors.toList());
-        }
-        Page<ChatRoom> chatRoom = chatRoomRepository.findChatRoom(accountId, pageable);
-        List<ChatRoomDto> chatRoomDtoList = chatRoom.stream()
-                .map(ChatRoomDto::new)
-                .collect(Collectors.toList());
-        return new PageImpl<>(chatRoomDtoList, pageable, chatRoom.getTotalElements());
+    public List<ChatRoom> findAllChatRoom(Long accountId) {
+        return chatRoomRepository.findAllChatRoom(accountId);
+    }
+
+    public QueryResults<ChatRoom> findChatRoomByPage(Long accountId, Pageable pageable) {
+        return chatRoomRepository.findChatRoomByPage(accountId, pageable);
     }
 
     public ChatRoomDto findById(Long chatRoomId) {

--- a/src/main/java/com/hipo/service/MessageService.java
+++ b/src/main/java/com/hipo/service/MessageService.java
@@ -1,25 +1,21 @@
 package com.hipo.service;
 
-import com.hipo.web.dto.MessageDto;
 import com.hipo.domain.entity.Account;
 import com.hipo.domain.entity.ChatRoom;
 import com.hipo.domain.entity.Message;
 import com.hipo.domain.entity.enums.MessageType;
-import com.hipo.utill.JudgeProcessor;
 import com.hipo.exception.NonExistResourceException;
 import com.hipo.repository.AccountRepository;
 import com.hipo.repository.ChatRoomRepository;
 import com.hipo.repository.MessageRepository;
+import com.hipo.utill.JudgeProcessor;
+import com.querydsl.core.QueryResults;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -42,22 +38,11 @@ public class  MessageService {
         return messageRepository.save(new Message(message, messageType, account, chatRoom));
     }
 
-    public Iterable<MessageDto> findChatRoomMessage(Long loginAccountId, Long chatRoomId, Pageable pageable, boolean all) {
+    public QueryResults<Message> findChatRoomMessageBySlice(Long loginAccountId, Long chatRoomId, Pageable pageable) {
+        return messageRepository.findChatRoomMessageBySlice(loginAccountId, chatRoomId, pageable);
+    }
 
-        if (all) {
-            List<MessageDto> messageList = messageRepository.findAllChatRoomMessage(loginAccountId, chatRoomId).stream()
-                    .map(MessageDto::new)
-                    .collect(Collectors.toList());
-            Collections.reverse(messageList);
-            return messageList;
-        }
-
-        Slice<Message> chatRoomMessage = messageRepository.findChatRoomMessage(loginAccountId, chatRoomId, pageable);
-        List<MessageDto> messageDtoList = chatRoomMessage.stream()
-                .map(MessageDto::new)
-                .collect(Collectors.toList());
-        Collections.reverse(messageDtoList);
-
-        return new SliceImpl<>(messageDtoList, pageable, chatRoomMessage.hasNext());
+    public List<Message> findAllChatRoomMessage(Long loginAccountId, Long chatRoomId) {
+        return messageRepository.findAllChatRoomMessage(loginAccountId, chatRoomId);
     }
 }

--- a/src/main/java/com/hipo/service/RelationService.java
+++ b/src/main/java/com/hipo/service/RelationService.java
@@ -55,14 +55,14 @@ public class RelationService {
                 .orElseThrow(() -> new NonExistResourceException("해당 Id를 갖는 Account를 찾을 수 없습니다."));
 
         Relation requestingRelation = relationRepository
-                .findByFromAccountAndToAccountAndRelationStateEquals(fromAccount, toAccount, RelationState.REQUEST)
-                .orElseThrow(() -> new NonExistResourceException("해당 fromAccount를 갖는 Relation을 찾을 수 없습니다."));
+                .findByFromAccountAndToAccountAndRelationStateEquals(toAccount, fromAccount, RelationState.REQUEST)
+                .orElseThrow(() -> new NonExistResourceException("해당 조건에 맞는 Relation을 찾을 수 없습니다."));
 
         requestingRelation.makeFriend();
 
         eventPublisher.publishEvent(new FriendAcceptEvent(requestingRelation));
 
-        Optional<Relation> optionalRelation = relationRepository.findByFromAccountAndToAccount(toAccount, fromAccount);
+        Optional<Relation> optionalRelation = relationRepository.findByFromAccountAndToAccount(fromAccount, toAccount);
         if (optionalRelation.isEmpty()) {
             Relation friend = Relation.builder()
                     .fromAccount(fromAccount)

--- a/src/main/java/com/hipo/test/RoomController.java
+++ b/src/main/java/com/hipo/test/RoomController.java
@@ -30,7 +30,7 @@ public class RoomController {
     @GetMapping(value = "/rooms")
     public String rooms(@RequestParam Long loginAccountId, Pageable pageable,
                         @RequestParam(value = "all", required = false) boolean all, Model model){
-        model.addAttribute("list", chatRoomService.findChatRoom(loginAccountId, pageable, all));
+        model.addAttribute("list", chatRoomService.findAllChatRoom(loginAccountId));
         model.addAttribute("account", accountRepository.findById(loginAccountId).orElse(null));
 
         return "/chatting/rooms";
@@ -40,8 +40,8 @@ public class RoomController {
     @GetMapping("/room/{roomId}")
     public String getRoom(@RequestParam Long loginAccountId, @PathVariable("roomId") Long roomId, Model model){
 
-        model.addAttribute("messages", messageService.findChatRoomMessage(loginAccountId, roomId,
-                PageRequest.of(0, 10), false));
+        model.addAttribute("messages", messageService.findChatRoomMessageBySlice(loginAccountId, roomId,
+                PageRequest.of(0, 10)));
         model.addAttribute("room", chatRoomRepository.findById(roomId).orElse(null));
         model.addAttribute("account", accountRepository.findById(loginAccountId).orElse(null));
         return "/chatting/room";

--- a/src/main/java/com/hipo/test/TestInit.java
+++ b/src/main/java/com/hipo/test/TestInit.java
@@ -4,6 +4,7 @@ import com.hipo.domain.entity.Account;
 import com.hipo.domain.entity.enums.Gender;
 import com.hipo.domain.entity.enums.Role;
 import com.hipo.service.AccountService;
+import com.hipo.service.RelationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -26,10 +27,12 @@ public class TestInit {
     static class InitService {
 
         private final AccountService accountService;
+        private final RelationService relationService;
         private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
         public void init() {
-            for (int i = 0; i < 20; i++) {
+            //make Account
+            for (int i = 1; i <= 20; i++) {
                 Account account = Account.builder()
                         .username("test" + i + "@test.com")
                         .password(bCryptPasswordEncoder.encode("1234"))
@@ -41,6 +44,19 @@ public class TestInit {
                         .build();
                 accountService.saveAccount(account);
             }
+
+            //make Relation
+            for (int i = 1; i <= 20; i++) {
+                Account fromAccount = accountService.findByNickname("test1Nickname");
+                Account toAccount = accountService.findByNickname("test" + i + "Nickname");
+                relationService.requestFriend(fromAccount.getId(), toAccount.getId());
+                relationService.acceptFriend(toAccount.getId(), fromAccount.getId());
+            }
+
+            //test20Nickname is Blocked
+            Account fromAccount = accountService.findByNickname("test1Nickname");
+            Account toAccount = accountService.findByNickname("test20Nickname");
+            relationService.block(fromAccount.getId(), toAccount.getId());
         }
     }
 

--- a/src/main/java/com/hipo/test/TestInit.java
+++ b/src/main/java/com/hipo/test/TestInit.java
@@ -46,7 +46,7 @@ public class TestInit {
             }
 
             //make Relation
-            for (int i = 1; i <= 20; i++) {
+            for (int i = 2; i <= 20; i++) {
                 Account fromAccount = accountService.findByNickname("test1Nickname");
                 Account toAccount = accountService.findByNickname("test" + i + "Nickname");
                 relationService.requestFriend(fromAccount.getId(), toAccount.getId());

--- a/src/main/java/com/hipo/validator/MessageValidator.java
+++ b/src/main/java/com/hipo/validator/MessageValidator.java
@@ -1,0 +1,32 @@
+package com.hipo.validator;
+
+import com.hipo.domain.entity.Account;
+import com.hipo.domain.entity.ChatRoom;
+import com.hipo.exception.IllegalRequestException;
+import com.hipo.exception.NonExistResourceException;
+import com.hipo.repository.AccountChatRoomRepository;
+import com.hipo.repository.AccountRepository;
+import com.hipo.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MessageValidator {
+
+    private final AccountRepository accountRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final AccountChatRoomRepository accountChatRoomRepository;
+
+    public void isChatRoomMember(Long accountId, Long chatRoomId) {
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new NonExistResourceException("해당 id를 갖는 Account를 찾을 수 없습니다."));
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new NonExistResourceException("해당 id를 갖는 ChatRoom을 찾을 수 없습니다."));
+
+        if (!accountChatRoomRepository.existsByAccountAndChatRoom(account, chatRoom)) {
+            throw new IllegalRequestException("해당 Account는 ChatRoom의 멤버가 아닙니다.");
+        }
+
+    }
+}

--- a/src/main/java/com/hipo/web/controller/ChatRoomController.java
+++ b/src/main/java/com/hipo/web/controller/ChatRoomController.java
@@ -1,17 +1,23 @@
 package com.hipo.web.controller;
 
 import com.hipo.argumentresolver.LoginAccountId;
+import com.hipo.domain.entity.ChatRoom;
 import com.hipo.service.ChatRoomService;
 import com.hipo.web.dto.ChatRoomDto;
 import com.hipo.web.dto.Result;
 import com.hipo.web.dto.ResultMessage;
 import com.hipo.web.form.ChatRoomMasterForm;
 import com.hipo.web.form.ChatRoomNameForm;
+import com.querydsl.core.QueryResults;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,12 +52,20 @@ public class ChatRoomController {
     }
 
     @GetMapping("/chatRooms")
-    public Object findChatRoom(@LoginAccountId Long loginAccountId, Pageable pageable,
-                                                      @RequestParam(value = "all", required = false) boolean all) {
-        if (all) {
-            return new Result<>(chatRoomService.findChatRoom(loginAccountId, pageable, all));
-        }
-        return chatRoomService.findChatRoom(loginAccountId, pageable, all);
+    public Page<ChatRoomDto> getChatRoomByPage(@LoginAccountId Long loginAccountId, Pageable pageable) {
+        QueryResults<ChatRoom> chatRoomQueryResults = chatRoomService.findChatRoomByPage(loginAccountId, pageable);
+        List<ChatRoomDto> chatRoomDtoList = chatRoomQueryResults.getResults().stream()
+                .map(ChatRoomDto::new)
+                .collect(Collectors.toList());
+        return new PageImpl<>(chatRoomDtoList, pageable, chatRoomQueryResults.getTotal());
+    }
+
+    @GetMapping("/chatRoom/all")
+    public Result<List<ChatRoomDto>> getAllChatRoom(@LoginAccountId Long loginAccountId) {
+        List<ChatRoomDto> chatRoomDtoList = chatRoomService.findAllChatRoom(loginAccountId).stream()
+                .map(ChatRoomDto::new)
+                .collect(Collectors.toList());
+        return new Result<>(chatRoomDtoList);
     }
 
     @GetMapping("/chatRoom/{id}")

--- a/src/main/java/com/hipo/web/controller/MessageController.java
+++ b/src/main/java/com/hipo/web/controller/MessageController.java
@@ -1,29 +1,58 @@
 package com.hipo.web.controller;
 
 import com.hipo.argumentresolver.LoginAccountId;
-import com.hipo.web.dto.Result;
+import com.hipo.domain.entity.Message;
 import com.hipo.service.MessageService;
+import com.hipo.validator.MessageValidator;
+import com.hipo.web.dto.MessageDto;
+import com.hipo.web.dto.Result;
+import com.querydsl.core.QueryResults;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
 public class MessageController {
 
     private final MessageService messageService;
+    private final MessageValidator messageValidator;
 
     @GetMapping("/message/{chatRoomId}")
-    public Object findChatRoomMessage(@LoginAccountId Long loginAccountId,
-                                      @PathVariable("chatRoomId") Long chatRoomId, Pageable pageable,
-                                      @RequestParam(value = "paged", required = false) boolean all) {
-        if (all) {
-            return new Result<>(messageService.findChatRoomMessage(loginAccountId, chatRoomId, pageable, all));
+    public Slice<MessageDto> getChatRoomMessageBySlice(@LoginAccountId Long loginAccountId,
+                                                       @PathVariable Long chatRoomId, Pageable pageable) {
+        messageValidator.isChatRoomMember(loginAccountId, chatRoomId);
+
+        QueryResults<Message> chatRoomMessageQueryResults =
+                messageService.findChatRoomMessageBySlice(loginAccountId, chatRoomId, pageable);
+
+        List<MessageDto> messageDtoList = chatRoomMessageQueryResults.getResults().stream()
+                .map(MessageDto::new)
+                .collect(Collectors.toList());
+
+        if (messageDtoList.size() == pageable.getPageSize() + 1) {
+            return new SliceImpl<>(messageDtoList.subList(0, pageable.getPageSize()), pageable, true);
+        } else {
+            return new SliceImpl<>(messageDtoList, pageable, false);
         }
-        return messageService.findChatRoomMessage(loginAccountId, chatRoomId, pageable, all);
     }
 
+    @GetMapping("message/all/{chatRoomId}")
+    public Result<List<MessageDto>> getAllChatRoomMessage(@LoginAccountId Long loginAccountId,
+                                                          @PathVariable Long chatRoomId) {
+        messageValidator.isChatRoomMember(loginAccountId, chatRoomId);
+
+        List<MessageDto> messageDtoList = messageService.findAllChatRoomMessage(loginAccountId, chatRoomId).stream()
+                .map(MessageDto::new)
+                .collect(Collectors.toList());
+
+        return new Result<>(messageDtoList);
+    }
 }

--- a/src/main/java/com/hipo/web/controller/RelationController.java
+++ b/src/main/java/com/hipo/web/controller/RelationController.java
@@ -37,7 +37,7 @@ public class RelationController {
     @PostMapping("/relation/request/accept/{accountId}")
     public ResultMessage acceptFriend(@LoginAccountId Long loginAccountId, @PathVariable Long accountId) {
         relationValidator.isBlockRelation(loginAccountId, accountId);
-        relationService.acceptFriend(accountId, loginAccountId);
+        relationService.acceptFriend(loginAccountId, accountId);
         return new ResultMessage("success accept friend request");
     }
 

--- a/src/main/java/com/hipo/web/dto/ChatRoomDto.java
+++ b/src/main/java/com/hipo/web/dto/ChatRoomDto.java
@@ -3,6 +3,9 @@ package com.hipo.web.dto;
 import com.hipo.domain.entity.ChatRoom;
 import lombok.Data;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Data
 public class ChatRoomDto {
 
@@ -10,8 +13,16 @@ public class ChatRoomDto {
 
     private String name;
 
+    private int size;
+
+    private List<AccountDto> participant;
+
     public ChatRoomDto(ChatRoom chatRoom) {
         this.id = chatRoom.getId();
         this.name = chatRoom.getName();
+        this.size = chatRoom.getParticipants().size();
+        this.participant = chatRoom.getParticipants().stream()
+                .map(accountChatRoom -> new AccountDto(accountChatRoom.getAccount()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/hipo/web/dto/ChatRoomDto.java
+++ b/src/main/java/com/hipo/web/dto/ChatRoomDto.java
@@ -15,14 +15,15 @@ public class ChatRoomDto {
 
     private int size;
 
-    private List<AccountDto> participant;
+    private List<AccountDto> participants;
 
     public ChatRoomDto(ChatRoom chatRoom) {
         this.id = chatRoom.getId();
         this.name = chatRoom.getName();
         this.size = chatRoom.getParticipants().size();
-        this.participant = chatRoom.getParticipants().stream()
+        this.participants = chatRoom.getParticipants().stream()
                 .map(accountChatRoom -> new AccountDto(accountChatRoom.getAccount()))
                 .collect(Collectors.toList());
+
     }
 }

--- a/src/main/java/com/hipo/web/dto/Result.java
+++ b/src/main/java/com/hipo/web/dto/Result.java
@@ -7,7 +7,4 @@ import lombok.Data;
 @AllArgsConstructor
 public class Result<T> {
     private T data;
-
-    public Result() {
-    }
 }


### PR DESCRIPTION
1. 조회 API 분리
- ChatRoom과 Message에서 "전체 조회"와 "페이지 조회"를 분리해서 각각 API를 생성
- fetchJoin과 QueryDSL을 사용해서 N + 1 방지

2. MessageValidator
 - MessageController에서 사용되는 MessageValidator 생성
- isChatRoomMember : Message를 조회하는 계정이 해당 ChatRoom에 속해있는지를 검증하는 메서드